### PR TITLE
Add config for overriding username

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ cd quarkus-to-kubernetes
 4. Add configuration to ./src/main/resources/application.properties
 ```
 quarkus.container-image.registry=quay.io
+# If your quay.io username is different from your local OS's username, specify your quay.io username here
+# quarkus.container-image.group=my_quay_username
 quarkus.container-image.builder=docker
 quarkus.kubernetes.ingress.expose=true
 #quarkus.kubernetes.ingress.host=quarkus-to-openshift-geoallenrh-dev.apps.sandbox-m2.ll9k.p1.openshiftapps.com


### PR DESCRIPTION
This is for folks who have quay.io usernames different from their local OS username. By default Quarkus uses the value of Java's `user.name` property which is by default the user's local hostname (e.g. the value of `whoami` on Linux). If the two aren't the same, Quarkus will fail when it tries to push the container image to the wrong Quay repository spec.